### PR TITLE
Add account registration contract

### DIFF
--- a/contracts/AccountRegistration.sol
+++ b/contracts/AccountRegistration.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.9;
+
+import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+contract AccountRegistration is ERC721Enumerable, Ownable {
+    constructor(
+        string memory name_,
+        string memory symbol_
+    ) ERC721(name_, symbol_) {}
+
+    function register(
+        address registrationAccount,
+        address tokenRecipient
+    ) external {
+        require(
+            registrationAccount == _msgSender(),
+            "AccountRegistration: registration account must be the sender"
+        );
+        uint256 tokenId = uint256(uint160(_msgSender()));
+        _mint(tokenRecipient, tokenId);
+    }
+
+    function unregister(uint256 tokenId) public virtual {
+        require(
+            _isApprovedOrOwner(_msgSender(), tokenId),
+            "ERC721: caller is not token owner or approved"
+        );
+        _burn(tokenId);
+    }
+}

--- a/contracts/ClaimSettlementBase.sol
+++ b/contracts/ClaimSettlementBase.sol
@@ -119,6 +119,7 @@ abstract contract ClaimSettlementBase is Module {
     }
 
     function isValidCaller(
+        address caller,
         bytes32 typehash,
         bytes memory callerData
     ) public view returns (bool) {
@@ -129,7 +130,7 @@ abstract contract ClaimSettlementBase is Module {
         }
         if (typehash == ADDRESS_TYPEHASH) {
             Address memory check = abi.decode(callerData, (Address));
-            if (check.caller == _msgSender()) {
+            if (check.caller == caller) {
                 return true;
             } else {
                 return false;
@@ -137,10 +138,7 @@ abstract contract ClaimSettlementBase is Module {
         }
         if (typehash == NFTOWNER_TYPEHASH) {
             NFTOwner memory check = abi.decode(callerData, (NFTOwner));
-            if (
-                IERC721(check.nftContract).ownerOf(check.tokenId) ==
-                _msgSender()
-            ) {
+            if (IERC721(check.nftContract).ownerOf(check.tokenId) == caller) {
                 return true;
             } else {
                 return false;
@@ -278,7 +276,7 @@ abstract contract ClaimSettlementBase is Module {
 
         // Check caller is allowed to perform the action
         require(
-            isValidCaller(callerTypehash, callerData),
+            isValidCaller(_msgSender(), callerTypehash, callerData),
             "Caller cannot claim"
         );
 

--- a/contracts/ClaimSettlementBase.sol
+++ b/contracts/ClaimSettlementBase.sol
@@ -87,7 +87,7 @@ abstract contract ClaimSettlementBase is Module {
         keccak256("TransferNFTToCaller(address token,uint256 tokenId)");
 
     modifier onlyAvatar() {
-        require(msg.sender == avatar, "caller is not the right avatar");
+        require(_msgSender() == avatar, "caller is not the right avatar");
         _;
     }
 
@@ -129,7 +129,7 @@ abstract contract ClaimSettlementBase is Module {
         }
         if (typehash == ADDRESS_TYPEHASH) {
             Address memory check = abi.decode(callerData, (Address));
-            if (check.caller == msg.sender) {
+            if (check.caller == _msgSender()) {
                 return true;
             } else {
                 return false;
@@ -138,7 +138,8 @@ abstract contract ClaimSettlementBase is Module {
         if (typehash == NFTOWNER_TYPEHASH) {
             NFTOwner memory check = abi.decode(callerData, (NFTOwner));
             if (
-                IERC721(check.nftContract).ownerOf(check.tokenId) == msg.sender
+                IERC721(check.nftContract).ownerOf(check.tokenId) ==
+                _msgSender()
             ) {
                 return true;
             } else {
@@ -204,7 +205,7 @@ abstract contract ClaimSettlementBase is Module {
             return
                 transferERC20(
                     action.token,
-                    msg.sender,
+                    _msgSender(),
                     Math.min(action.amount, currentBalance)
                 );
         }
@@ -213,7 +214,7 @@ abstract contract ClaimSettlementBase is Module {
                 actionData,
                 (TransferNFTToCaller)
             );
-            return transferERC721(action.token, msg.sender, action.tokenId);
+            return transferERC721(action.token, _msgSender(), action.tokenId);
         }
         revert("Action not supported");
     }

--- a/test/AccountRegistration.spec.ts
+++ b/test/AccountRegistration.spec.ts
@@ -1,0 +1,115 @@
+import "@nomiclabs/hardhat-ethers";
+
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { loadFixture } from "@nomicfoundation/hardhat-network-helpers";
+
+import { setupAvatar, setupTokens } from "./fixtures";
+import { BigNumber, Contract } from "ethers";
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+describe("accountRegistration", async () => {
+  let staking: Contract,
+    account1: SignerWithAddress,
+    account2: SignerWithAddress;
+  async function setupFixture() {
+    const [account1, account2] = await ethers.getSigners();
+    const { staking } = await setupTokens();
+    const { avatar, tx } = await setupAvatar();
+    return {
+      wallets: {
+        account1,
+        account2,
+      },
+      assets: {
+        staking,
+      },
+      avatar,
+      tx,
+    };
+  }
+  beforeEach(async () => {
+    const fixture = await loadFixture(setupFixture);
+
+    staking = fixture.assets.staking;
+
+    account1 = fixture.wallets.account1;
+    account2 = fixture.wallets.account2;
+  });
+  describe("Registering", async () => {
+    it("Can register self and receive NFT", async () => {
+      await staking
+        .connect(account1)
+        .register(account1.address, account1.address);
+      expect(await staking.ownerOf(BigNumber.from(account1.address))).to.equal(
+        account1.address
+      );
+    });
+    it("Can list all NFTs owned by a user", async () => {
+      // Transfer two to the same account
+      await staking
+        .connect(account1)
+        .register(account1.address, account2.address);
+      await staking
+        .connect(account2)
+        .register(account2.address, account2.address);
+
+      expect(await staking.balanceOf(account2.address)).to.equal(2);
+
+      // Get both held tokens
+      const heldNfts = [
+        (await staking.tokenOfOwnerByIndex(account2.address, 0)).toString(),
+        (await staking.tokenOfOwnerByIndex(account2.address, 1)).toString(),
+      ];
+      // Convert to strings to avoid casing issues with hex & BigNumber
+      expect(heldNfts).to.include.members([
+        BigNumber.from(account1.address).toString(),
+        BigNumber.from(account2.address).toString(),
+      ]);
+    });
+    it("Can register self and receive NFT in another account", async () => {
+      await staking
+        .connect(account1)
+        .register(account1.address, account2.address);
+      expect(await staking.ownerOf(BigNumber.from(account1.address))).to.equal(
+        account2.address
+      );
+    });
+    it("Does not let an account register on behalf of another", async () => {
+      await expect(
+        staking.connect(account2).register(account1.address, account2.address)
+      ).to.be.revertedWith(
+        "AccountRegistration: registration account must be the sender"
+      );
+    });
+  });
+  describe("Unregistering", async () => {
+    it("Can remove tokens owned by self", async () => {
+      await staking
+        .connect(account1)
+        .register(account1.address, account1.address);
+      expect(await staking.ownerOf(BigNumber.from(account1.address))).to.equal(
+        account1.address
+      );
+      await staking
+        .connect(account1)
+        .unregister(BigNumber.from(account1.address));
+      await expect(
+        staking.ownerOf(BigNumber.from(account1.address))
+      ).to.be.revertedWith("ERC721: invalid token ID");
+    });
+    it("Cannot unregister from an account that doesn't own the NFT", async () => {
+      // Register 1 and and transfer to 2
+      await staking
+        .connect(account1)
+        .register(account1.address, account2.address);
+      expect(await staking.ownerOf(BigNumber.from(account1.address))).to.equal(
+        account2.address
+      );
+      // Try to unregister from 1
+      await expect(
+        staking.connect(account1).unregister(BigNumber.from(account1.address))
+      ).to.be.revertedWith("ERC721: caller is not token owner or approved");
+    });
+  });
+});

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -13,7 +13,14 @@ export const setupTokens = async () => {
     signer: deployer,
   });
   const nft = await Nft.deploy("TestNft", "TestNft");
-  return { token, gasToken, nft };
+  const Staking = await ethers.getContractFactory("AccountRegistration", {
+    signer: deployer,
+  });
+  const staking = await Staking.deploy(
+    "AccountRegistration",
+    "AccountRegistration"
+  );
+  return { token, gasToken, nft, staking };
 };
 export const setupAvatar = async (owner?: SignerWithAddress) => {
   const avatarFactory = await ethers.getContractFactory("TestAvatar", {


### PR DESCRIPTION
A small addition to support the staking process. I also changed msg.sender to _msgSender() as that's what's used across the OZ contracts, and is I think there to support some account abstraction.

The registering function could work without passing in the current address, but I thought it'd be clearer in the API which address is being registered and which is where the token should be sent with having two addresses.