### PR TITLE
Add place for explainability config to go

### DIFF
--- a/contracts/ClaimSettlementBase.sol
+++ b/contracts/ClaimSettlementBase.sol
@@ -11,6 +11,7 @@ abstract contract ClaimSettlementBase is Module {
 
     bytes32 public domainSeparator;
     EIP712Domain public domain;
+    string public configuration;
 
     struct EIP712Domain {
         string name;
@@ -86,9 +87,16 @@ abstract contract ClaimSettlementBase is Module {
     bytes32 public constant TRANSFERNFTTOCALLER_TYPEHASH =
         keccak256("TransferNFTToCaller(address token,uint256 tokenId)");
 
+    event ConfigurationChanged(string configuration);
+
     modifier onlyAvatar() {
         require(msg.sender == avatar, "caller is not the right avatar");
         _;
+    }
+
+    function setConfiguration(string memory _configuration) public onlyAvatar {
+        configuration = _configuration;
+        emit ConfigurationChanged(_configuration);
     }
 
     function isValidState(

--- a/test/ClaimSettlement.spec.ts
+++ b/test/ClaimSettlement.spec.ts
@@ -494,4 +494,42 @@ describe("claimSettlement", async () => {
       ).to.have.equal(true);
     });
   });
+  describe("setConfiguration()", async () => {
+    let avatar: Contract, claimSettlement: Contract, payee1: SignerWithAddress;
+    beforeEach(async () => {
+      const fixture = await loadFixture(setupFixture);
+      avatar = fixture.avatar;
+      claimSettlement = fixture.modules.claimSettlement;
+      payee1 = fixture.wallets.payee1;
+    });
+    it("avatar can add configuration", async () => {
+      const did = "did:1234";
+      const data = claimSettlement.interface.encodeFunctionData(
+        "setConfiguration",
+        [did]
+      );
+      await expect(
+        await avatar.execTransaction(
+          claimSettlement.address,
+          0,
+          data,
+          0,
+          0,
+          0,
+          0,
+          AddressZero,
+          AddressZero,
+          "0x"
+        )
+      )
+        .to.emit(claimSettlement, "ConfigurationChanged")
+        .withArgs(did);
+      expect(await claimSettlement.configuration()).to.equal(did);
+    });
+    it("non-avatar cannot add configuration", async () => {
+      await expect(
+        claimSettlement.connect(payee1).setConfiguration("did:1234")
+      ).to.be.revertedWith("caller is not the right avatar");
+    });
+  });
 });


### PR DESCRIPTION
The contract side of this is quite simple as it's a straight bit of storage. On the other side we should match the format we've been using so far (and storing just a DID in the contract) - just remove the computation specific parts for now and keep the explainations/names/etc.